### PR TITLE
Fix the SetItem calls and add a dedicated test.

### DIFF
--- a/src/py.ml
+++ b/src/py.ml
@@ -56,6 +56,7 @@ module PyList = struct
     let create l =
         let lst = C._PyList_New (List.length l |> Int64.of_int) in
         List.iteri (fun i x ->
+            C._Py_IncRef x;
             wrap_status (C._PyList_SetItem lst (Int64.of_int i) x)) l; wrap lst
 
     let insert l i v =
@@ -84,6 +85,7 @@ module PyTuple = struct
     let create l =
         let tpl = C._PyTuple_New (Array.length l |> Int64.of_int) in
         Array.iteri (fun i x ->
+            C._Py_IncRef x;
             wrap_status (C._PyTuple_SetItem tpl (Int64.of_int i) x)) l; wrap tpl
 end
 

--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -78,6 +78,15 @@ let py_test_thread_state t =
     let _ = PyThreadState.swap a0 in
     Test.check t "Old thread state" (fun () -> eval "a" |> Object.to_int) 10
 
+let py_test_gc t =
+    List.iter (fun to_python_fn ->
+        let array = Array.init 1000 (fun i -> i * i) in
+        let tuple = !$(to_python_fn (Array.map (fun i -> Int i) array)) in
+        Gc.full_major ();
+        let array' = Object.to_array Object.to_int tuple in
+        Test.check t "Python gc test" (fun () -> array) array')
+        [(fun x -> Tuple x); (fun x -> List (Array.to_list x))]
+
 
 let simple = [
     py_test_int;
@@ -89,6 +98,7 @@ let simple = [
     py_test_iter;
     py_test_buffer;
     py_test_thread_state;
+    py_test_gc;
 ]
 
 let _ =


### PR DESCRIPTION
Hello,
While experimenting with these python bindings, I ran into some segmentation fault.
I think these were caused by the calls to `PyTuple_SetItem` and `PyList_SetItem`. As highlighted in [this part of the python C api doc](https://docs.python.org/3/c-api/tuple.html?highlight=pytuple_setitem#c.PyTuple_SetItem) these functions _steal_ the references that they are given so they will not increase the reference count and will still consider that the object remains alive. The fix is simply to increase the reference count when calling this function to account for the reference on the ocaml side which will later be collected when the ocaml gc triggers.
I've also added a test case with some explicit gc triggering that segfaulted with the old code and now works fine.

(also conversly `PyTuple_GetItem` and `PyList_GetITem` return a borrowed reference but it turns out that `ocaml-py` use `PyObject_GetItem` which safely returns a new reference)
