### PR TITLE
Add some numpy support with numpy to bigarray conversion.

### DIFF
--- a/src/init.ml
+++ b/src/init.ml
@@ -229,3 +229,5 @@ let _PyByteArray_AsString = foreign ~from "PyByteArray_AsString" (pyobject @-> r
 let _PyByteArray_Size = foreign ~from "PyByteArray_Size" (pyobject @-> returning int64_t)
 let _PyByteArray_FromStringAndSize = foreign ~from "PyByteArray_FromStringAndSize" (ptr char @-> int64_t @-> returning pyobject)
 let _PySlice_New = foreign ~from "PySlice_New" (pyobject @-> pyobject @-> pyobject @-> returning pyobject)
+
+let _PyCapsule_GetPointer = foreign ~from "PyCapsule_GetPointer" (pyobject @-> ptr char @-> returning (ptr void))

--- a/src/py.ml
+++ b/src/py.ml
@@ -683,4 +683,135 @@ let print ?kwargs args =
     run (eval "print") args ?kwargs
     |> ignore
 
+module Numpy = struct
+    let shape pyobject =
+        Object.to_list Object.to_int (pyobject $. (String "shape"))
+
+    type t = {
+        get_version : unit -> int;
+        get_ptr : pyobject -> Intptr.t Ctypes_static.ptr -> unit Ctypes_static.ptr;
+        object_type : pyobject -> int -> int;
+        array_new : unit -> pyobject;
+    }
+
+    let is_available () =
+        try
+            let _ = PyModule.import "numpy" in
+            true
+        with _ -> false
+
+    let typenum = function
+      | `bool -> 0
+      | `byte -> 1
+      | `ubyte -> 2
+      | `short -> 3
+      | `ushort -> 4
+      | `int -> 5
+      | `uint -> 6
+      | `long -> 7
+      | `ulong -> 8
+      | `longlong -> 9
+      | `ulonglong -> 10
+      | `float -> 11
+      | `double -> 12
+      | `longdouble -> 13
+
+    let t =
+        lazy (
+            let np = PyModule.import "numpy" in
+            let np_api =
+                np $. (String "core") $. (String "multiarray") $. (String "_ARRAY_API")
+            in
+            let np_api = Object.to_c_pointer np_api None in
+            (* See [numpy/__multiarray_api.h] for the offset values. *)
+            let ptr_offset ~offset =
+                Ctypes.(to_voidp (from_voidp (ptr void) np_api +@ offset))
+            in
+            let fn fn_typ ~offset =
+                Ctypes.(!@ (from_voidp (Foreign.funptr fn_typ) (ptr_offset ~offset)))
+            in
+            let get_version = fn Ctypes.(void @-> returning uint) ~offset:0 in
+            let get_version () = get_version () |> Unsigned.UInt.to_int in
+            let descr_from_type = fn Ctypes.(int @-> returning (ptr void)) ~offset:45 in
+            let typeobject_from_type = fn Ctypes.(int @-> returning (ptr void)) ~offset:46 in
+            let get_ptr =
+              Ctypes.(pyobject @-> ptr intptr_t @-> returning (ptr void))
+              |> fn ~offset:160
+            in
+            let zero_fn =
+                Ctypes.(
+                    int @->
+                    ptr intptr_t @->
+                    ptr void @->
+                    int @->
+                    returning pyobject)
+                |> fn ~offset:183
+            in
+            let array_type = ptr_offset ~offset:2 in
+            let array_new =
+                Ctypes.(
+                    ptr void @-> (* subtype *)
+                    int @-> (* ndims *)
+                    ptr intptr_t @-> (* dims *)
+                    int @-> (* typenum *)
+                    ptr void @-> (* strides *)
+                    ptr void @-> (* data *)
+                    int @-> (* item size *)
+                    int @-> (* flags *)
+                    pyobject @->
+                    returning pyobject)
+                |> fn ~offset:93
+            in
+            let array_new () =
+                let typenum = typenum `byte in
+                let data = CArray.make char 500 |> CArray.start |> to_voidp in
+                let dims = CArray.of_list intptr_t [ Intptr.of_int 4 ] |> CArray.start in
+                ignore (data, dims, typenum, array_type, array_new, descr_from_type, zero_fn);
+                ignore (typeobject_from_type, ());
+                let zero = wrap (zero_fn 1 dims (descr_from_type 11) 0) in
+                let zero = (np $. (String "exp")) $ [ Ptr zero ] in
+                let zero = (np $. (String "exp")) $ [ Ptr zero ] in
+                Printf.printf "here %s\n%!" (Object.to_string zero);
+                (* let array_type = typeobject_from_type 0 |> wrap in *)
+                wrap (array_new array_type 1 dims 0 null null 0 0 null)
+            in
+            let object_type = Ctypes.(ptr void @-> int @-> returning int) |> fn ~offset:54 in
+            { get_version; array_new; get_ptr; object_type })
+
+    let get_version () = (Lazy.force t).get_version ()
+    let array_new () = (Lazy.force t).array_new ()
+
+    let numpy_to_bigarray : type a b . pyobject -> (a, b) Bigarray.kind -> (a, b, Bigarray.c_layout) Bigarray.Genarray.t = fun pyobject kind ->
+        let t = Lazy.force t in
+        let shape = shape pyobject in
+        let zeros =
+          List.map (fun _ -> Intptr.of_int 0) shape
+          |> CArray.of_list intptr_t
+          |> CArray.start
+        in
+        let typeinfo = t.object_type pyobject 0 in
+        let typ : a typ =
+          match kind, typeinfo with
+          | Bigarray.Float32, 11 -> float
+          | Bigarray.Float64, 12 -> float
+          | Bigarray.Int8_signed, 1 -> int
+          | Bigarray.Int8_unsigned, 2 -> int
+          | Bigarray.Int16_signed, 3 -> int
+          | Bigarray.Int16_unsigned, 4 -> int
+          | Bigarray.Int32, (5 | 7) -> int32_t
+          | Bigarray.Int64, 9 -> int64_t
+          | Bigarray.Int, _ -> failwith "int is not supported"
+          | Bigarray.Nativeint, _ -> failwith "native int is not supported"
+          | Bigarray.Complex32, _ -> failwith "complex32 is not supported"
+          | Bigarray.Complex64, _ -> failwith "complex64 is not supported"
+          | Bigarray.Char, _ -> char
+          | _ -> Printf.sprintf "incompatible numpy array type %d" typeinfo |> failwith
+        in
+        let ptr = t.get_ptr pyobject zeros |> from_voidp typ in
+        let bigarray = bigarray_of_ptr Genarray (Array.of_list shape) kind ptr in
+        C._Py_IncRef pyobject;
+        Gc.finalise (fun _ -> C._Py_DecRef pyobject) bigarray;
+        bigarray
+end
+
 let () = initialize ()

--- a/src/py.ml
+++ b/src/py.ml
@@ -420,6 +420,21 @@ module Object = struct
     let concat a b =
         wrap (C._PySequence_Concat a b)
 
+    let to_c_pointer t str_option =
+        let str_or_null =
+            match str_option with
+            | Some str -> CArray.of_string str |> CArray.start
+            | None -> from_voidp char null
+        in
+        let ptr = C._PyCapsule_GetPointer t str_or_null in
+        if ptr = null
+        then
+            let err = get_python_error () in
+            let () = C._PyErr_Clear () in
+            raise err
+        else ptr
+
+
     (** Call a Python Object *)
     let call ?args:(args=PyTuple.create [||]) ?kwargs fn =
         let kw = match kwargs with

--- a/src/py.mli
+++ b/src/py.mli
@@ -122,6 +122,9 @@ module Object : sig
 
     (** Call a Python Object *)
     val call : ?args:t -> ?kwargs:t -> t -> t
+
+    (** Extract the C pointer from a capsule *)
+    val to_c_pointer : t -> string option -> unit Ctypes.ptr
 end
 
 val wrap : pyobject -> Object.t

--- a/src/py.mli
+++ b/src/py.mli
@@ -333,7 +333,7 @@ module Numpy : sig
     (* Return a bigarray based on some numpy array by sharing memory between
        the two.
        This raises if the provided kind is not compatible with the numpy
-       array element types.
+       array element types or if the numpy array is not C contiguous.
     *)
     val numpy_to_bigarray :
         pyobject ->

--- a/src/py.mli
+++ b/src/py.mli
@@ -329,6 +329,12 @@ module Numpy : sig
     val is_available : unit -> bool
     val shape : pyobject -> int list
     val get_version : unit -> int
+
+    (* Return a bigarray based on some numpy array by sharing memory between
+       the two.
+       This raises if the provided kind is not compatible with the numpy
+       array element types.
+    *)
     val numpy_to_bigarray :
         pyobject ->
         ('a, 'b) Bigarray.kind ->

--- a/src/py.mli
+++ b/src/py.mli
@@ -325,6 +325,14 @@ val pickle : ?kwargs:(t * t) list -> Object.t -> bytes
 val unpickle : ?kwargs:(t * t) list -> bytes -> Object.t
 val print : ?kwargs:(t * t) list -> t list -> unit
 
+module Numpy : sig
+    val is_available : unit -> bool
+    val shape : pyobject -> int list
+    val get_version : unit -> int
+    val array_new : unit -> Object.t
+    val numpy_to_bigarray : pyobject -> ('a, 'b) Bigarray.kind -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+end
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2017 Zach Shipko
 

--- a/src/py.mli
+++ b/src/py.mli
@@ -329,8 +329,10 @@ module Numpy : sig
     val is_available : unit -> bool
     val shape : pyobject -> int list
     val get_version : unit -> int
-    val array_new : unit -> Object.t
-    val numpy_to_bigarray : pyobject -> ('a, 'b) Bigarray.kind -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+    val numpy_to_bigarray :
+        pyobject ->
+        ('a, 'b) Bigarray.kind ->
+        ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
 end
 
 (*---------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds some support for numpy array to bigarray conversion, this is done by sharing memory so should be efficient. The change is not that big but I'm happy to put it in a different file if you think it's better (I think it's probably worth having here rather than in another library, especially as it's lazy and doesn't require numpy to be installed to work).

In more details, the changes are:
- Adding and exposing some wrappers for `PyCapsule_GetPointer`. Capsules are the standard way to share opaque pointers via python.
- Use the numpy capsule to access the numpy api, in particular the `PyArray_GetPtr` function. This provides a pointer to a table of functions. Ctypes make it possible to run these functions from ocaml.
- Wrap this call together with some bigarray creation. Ensure that the numpy array lives at least as long as the bigarray by incrementing the ref count and decrementing only on finalization.
- Add a test, this test only runs if numpy is installed as this would not always be the case.

If this sounds ok to you, I would also like to add some conversion the other way around, i.e. creating a numpy array from a bigarray by sharing memory.
(my use case for this is using the openai gym from ocaml where lots of data gets transmitted so performance could be a concern)