### PR TITLE
Add a function to convert bigarrays to numpy arrays

### DIFF
--- a/src/py.ml
+++ b/src/py.ml
@@ -689,7 +689,7 @@ module Numpy = struct
 
     type t = {
         get_version : unit -> Unsigned.uint;
-        get_ptr : pyobject -> Intptr.t Ctypes_static.ptr -> unit Ctypes_static.ptr;
+        get_ptr : pyobject -> Intptr.t ptr -> unit ptr;
         object_type : pyobject -> int -> int;
         np : pyobject;
     }
@@ -707,20 +707,15 @@ module Numpy = struct
         in
         let np_api = Object.to_c_pointer np_api None in
         (* See [numpy/__multiarray_api.h] for the offset values. *)
-        let ptr_offset ~offset =
-            Ctypes.(to_voidp (from_voidp (ptr void) np_api +@ offset))
-        in
+        let ptr_offset ~offset = to_voidp (from_voidp (ptr void) np_api +@ offset) in
         let fn fn_typ ~offset =
-            Ctypes.(!@ (from_voidp (Foreign.funptr fn_typ) (ptr_offset ~offset)))
+            !@ (from_voidp (Foreign.funptr fn_typ) (ptr_offset ~offset))
         in
-        let get_version = fn Ctypes.(void @-> returning uint) ~offset:0 in
+        let get_version = fn (void @-> returning uint) ~offset:0 in
         let get_ptr =
-          Ctypes.(pyobject @-> ptr intptr_t @-> returning (ptr void))
-          |> fn ~offset:160
+            fn (pyobject @-> ptr intptr_t @-> returning (ptr void)) ~offset:160
         in
-        let object_type =
-            Ctypes.(ptr void @-> int @-> returning int) |> fn ~offset:54
-        in
+        let object_type = fn (ptr void @-> int @-> returning int) ~offset:54 in
         { get_version; get_ptr; object_type; np }
 
     let t = lazy (init ())

--- a/src/py.ml
+++ b/src/py.ml
@@ -806,7 +806,9 @@ module Numpy = struct
         in
         let data = bigarray_start Genarray bigarray |> to_voidp in
         let pyobject =
-            t.new_array t.array_type ndims dims typeinfo (from_voidp npy_intp null) data 0 1081 null
+            (* NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE *)
+            let flag = 0x0001 lor 0x0100 lor 0x0400 in
+            t.new_array t.array_type ndims dims typeinfo (from_voidp npy_intp null) data 0 flag null
             |> wrap
         in
         (* Ensure that the bigarray can only be collected after the numpy array. Use

--- a/src/py.mli
+++ b/src/py.mli
@@ -339,6 +339,12 @@ module Numpy : sig
         pyobject ->
         ('a, 'b) Bigarray.kind ->
         ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+
+    (* Return a numpy array based on a bigarray by sharing memory between the
+       two.
+    *)
+    val bigarray_to_numpy :
+        ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> pyobject
 end
 
 (*---------------------------------------------------------------------------


### PR DESCRIPTION
This closes the loop by adding a function that converts a bigarray to a numpy array. Again to ensure good performance, the memory is shared between the two arrays.
This also adds some small test for this feature.