### PR TITLE
Clean the second interpreter at the end of the thread state test.

### DIFF
--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -76,7 +76,11 @@ let py_test_thread_state t =
     let _ = exec "a = 5" in
     let _ = Test.check t "New thread state" (fun () -> eval "a" |> Object.to_int) 5 in
     let _ = PyThreadState.swap a0 in
-    Test.check t "Old thread state" (fun () -> eval "a" |> Object.to_int) 10
+    Test.check t "Old thread state" (fun () -> eval "a" |> Object.to_int) 10;
+    let a1 = new_interpreter () in
+    end_interpreter a1;
+    let _ = PyThreadState.swap a0 in
+    ()
 
 let py_test_gc t =
     List.iter (fun to_python_fn ->


### PR DESCRIPTION
Thread states are very tricky to manipulate (see [bugs and cavehats](https://docs.python.org/3/c-api/init.html#bugs-and-caveats)). In particular they don't work well with modules that use extensions.
This may be the cause of the segfault I saw #9 as numpy use extensions.
Anyway I didn't see any segfault after the change from this PR even running the tests in a loop so I think it's good enough to close the issue if nobody else is having problems.