### PR TITLE
Small refactoring around error handling

### DIFF
--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -122,6 +122,17 @@ let py_test_numpy t =
             (fun () -> (Bigarray.Genarray.get bigarray [| 1; 1 |] -. 3.14) < 1e-6) true
     )
 
+let py_test_errors t =
+    let v = Py.to_object (Int (-1)) |> Py.Object.to_int in
+    Test.check t "error can return -1" (fun () -> v) (-1);
+    let ok =
+        try
+            let _ = Py.to_object (String "aa") |> Py.Object.to_int in
+            false
+        with _ -> true
+    in
+    Test.check t "error string to int" (fun () -> ok) true
+
 let simple = [
     py_test_int;
     py_test_string;
@@ -134,6 +145,7 @@ let simple = [
     py_test_thread_state;
     py_test_gc;
     py_test_numpy;
+    py_test_errors;
 ]
 
 let _ =


### PR DESCRIPTION
(sorry to push that much on ocaml-py right now, hopefully it almost match my needs after another PR for ocaml values wrapping)

With the current error handling, `Object.to_int` called on a python string would return -1 but not raise an error. Moreover as the python error is set and not cleaned this could result in an error the next time a python function is called with a rather uninformative error message (the function returned a value but the error message is set).
Tweak error handling so that an exception is raised in this case. As per the [doc](https://docs.python.org/3/c-api/long.html#c.PyLong_AsLong) disambiguation is performed by looking at `PyErr_Occured`.