### PR TITLE
Run ocaml modules from python

### DIFF
--- a/src/init.ml
+++ b/src/init.ml
@@ -250,4 +250,17 @@ let _PyByteArray_Size = foreign ~from "PyByteArray_Size" (pyobject @-> returning
 let _PyByteArray_FromStringAndSize = foreign ~from "PyByteArray_FromStringAndSize" (ptr char @-> int64_t @-> returning pyobject)
 let _PySlice_New = foreign ~from "PySlice_New" (pyobject @-> pyobject @-> pyobject @-> returning pyobject)
 
+type _Py_method
+let _Py_method : _Py_method structure typ = structure "Py_method"
+let ml_name = field _Py_method "ml_name" string
+let ml_meth = field _Py_method "ml_meth" (Foreign.funptr (pyobject @-> pyobject @-> returning pyobject))
+let ml_flags = field _Py_method "ml_flag" int
+let ml_doc = field _Py_method "ml_doc" string
+let () = seal _Py_method
+
+let pymethod = ptr _Py_method
+
+let _PyCFunction_New =
+  foreign ~from "PyCFunction_NewEx" (pymethod @-> pyobject @-> pyobject @-> returning pyobject)
+
 let _PyCapsule_GetPointer = foreign ~from "PyCapsule_GetPointer" (pyobject @-> ptr char @-> returning (ptr void))

--- a/src/init.ml
+++ b/src/init.ml
@@ -119,6 +119,8 @@ let _PyRun_StringFlags = foreign ~from "PyRun_StringFlags" (string @-> int @-> p
 let _PyErr_Clear = foreign ~from "PyErr_Clear" (void @-> returning void)
 let _PyErr_Fetch = foreign ~from "PyErr_Fetch" (ptr pyobject @-> ptr pyobject @-> ptr pyobject @-> returning int)
 let _PyErr_Occurred = foreign ~from "PyErr_Occurred" (void @-> returning int)
+let _PyErr_SetString = foreign ~from "PyErr_SetString" (pyobject @-> string @-> returning void)
+let _PyExc_RuntimeError = foreign_value ~from "PyExc_RuntimeError" pyobject
 
 (* Module *)
 let _PyModule_GetDict = foreign ~from "PyModule_GetDict" (pyobject @-> returning pyobject)
@@ -262,5 +264,9 @@ let pymethod = ptr _Py_method
 
 let _PyCFunction_New =
   foreign ~from "PyCFunction_NewEx" (pymethod @-> pyobject @-> pyobject @-> returning pyobject)
+
+let _PyCapsule_New =
+  foreign ~from "PyCapsule_New" (ptr void @-> ptr char @->
+    (Foreign.funptr (pyobject @-> returning void)) @-> returning pyobject)
 
 let _PyCapsule_GetPointer = foreign ~from "PyCapsule_GetPointer" (pyobject @-> ptr char @-> returning (ptr void))

--- a/src/py.ml
+++ b/src/py.ml
@@ -700,8 +700,11 @@ let print ?kwargs args =
     run (eval "print") args ?kwargs
     |> ignore
 
+(* Avoid the GC collecting the struct as Python does not seem to copy them. *)
+let all_methods = ref []
 let c_function fn m ~name =
     let pymethod = allocate_n C._Py_method ~count:1 in
+    all_methods := pymethod :: !all_methods;
     setf !@ pymethod ml_name name;
     setf !@ pymethod ml_meth fn;
     setf !@ pymethod ml_flags 1;
@@ -861,8 +864,53 @@ module CamlModule = struct
 
     let add_fn t name fn =
         fns := fn :: !fns;
-        let fn _none args = fn args |> to_object in
+        let fn _none args =
+            try
+                fn args |> to_object
+            with
+            | exn ->
+                (* Set an ocaml related exception then return null. *)
+                _PyErr_SetString
+                    (!@_PyExc_RuntimeError)
+                    (Printf.sprintf "ocaml-error: %s" (Printexc.to_string exn));
+                null
+        in
         PyModule.add_object t name (c_function fn (Object.none ()) ~name)
+
+    (* Wrap ocaml values so that they can be passed through Python and
+       used by further OCaml code.
+       The values are stored in a capsule. In order to keep the GC happy, we don't
+       use a pointer but an identifier related to a hashtable where values are
+       stored.
+    *)
+    let delete_fns = ref []
+    let capsule_wrapper () =
+        let values = Hashtbl.create 100 in
+        let counter = ref 1 in
+        let id_from_capsule capsule =
+            _PyCapsule_GetPointer capsule (from_voidp char null)
+            |> raw_address_of_ptr |> Nativeint.to_int
+        in
+        let delete_id ptr = Hashtbl.remove values (id_from_capsule ptr) in
+        delete_fns := delete_id :: !delete_fns;
+        let encapsulate v =
+            let id = !counter in
+            counter := !counter + 1;
+            Hashtbl.add values id v;
+            _PyCapsule_New
+                (ptr_of_raw_address (Nativeint.of_int id))
+                (from_voidp char null)
+                delete_id
+            |> wrap
+        in
+        let decapsulate capsule =
+            let id = id_from_capsule capsule in
+            match Hashtbl.find_opt values id with
+            | None ->
+                Printf.sprintf "internal error: id %d cannot be found" id |> failwith
+            | Some v -> v
+        in
+        encapsulate, decapsulate
 end
 
 let () = initialize ()

--- a/src/py.ml
+++ b/src/py.ml
@@ -505,6 +505,9 @@ module PyModule = struct
         wrap_status (C._PyModuleAddStringConstant m name v)
 
     let add_object m name obj =
+        (* PyModule_AddObject steals the reference to obj so we first increase
+           the refcount. *)
+        Object.incref obj;
         wrap_status (C._PyModuleAddObject m name obj)
 
     let main () =
@@ -697,6 +700,15 @@ let print ?kwargs args =
     run (eval "print") args ?kwargs
     |> ignore
 
+let c_function fn m ~name =
+    let pymethod = allocate_n C._Py_method ~count:1 in
+    setf !@ pymethod ml_name name;
+    setf !@ pymethod ml_meth fn;
+    setf !@ pymethod ml_flags 1;
+    setf !@ pymethod ml_doc "doc";
+    let name = to_object (String name) in
+    wrap (_PyCFunction_New pymethod m name)
+
 module Numpy = struct
     (* Define some type aliases to match the numpy conventions. *)
     let npy_intp = intptr_t
@@ -830,6 +842,27 @@ module Numpy = struct
         *)
         Gc.finalise (fun _ -> ignore (Sys.opaque_identity bigarray)) pyobject;
         pyobject
+end
+
+(* A simple module to wrap OCaml code that can be run from Python. *)
+module CamlModule = struct
+    type pyvalue = t
+    type t = Object.t
+
+    let create name = PyModule.get name
+
+    let add_int = PyModule.add_int
+    let add_string = PyModule.add_string
+    let add_object t name o = PyModule.add_object t name (to_object o)
+
+    (* In order to avoid the closures being potentially collected by the OCaml GC
+       we store them in a global reference. *)
+    let fns = ref []
+
+    let add_fn t name fn =
+        fns := fn :: !fns;
+        let fn _none args = fn args |> to_object in
+        PyModule.add_object t name (c_function fn (Object.none ()) ~name)
 end
 
 let () = initialize ()

--- a/src/py.mli
+++ b/src/py.mli
@@ -328,6 +328,12 @@ val pickle : ?kwargs:(t * t) list -> Object.t -> bytes
 val unpickle : ?kwargs:(t * t) list -> bytes -> Object.t
 val print : ?kwargs:(t * t) list -> t list -> unit
 
+(** [c_function fn obj ~name] returns a Python function. When this function
+    is called on some arguments [args], [fn obj args] is called.
+*)
+val c_function :
+    (Object.t -> Object.t -> Object.t) -> Object.t -> name:string -> Object.t
+
 module Numpy : sig
     val is_available : unit -> bool
     val shape : pyobject -> int list
@@ -348,6 +354,16 @@ module Numpy : sig
     *)
     val from_bigarray :
         ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> pyobject
+end
+
+module CamlModule : sig
+    type pyvalue = t
+    type t
+    val create : string -> t
+    val add_int : t -> string -> int -> unit
+    val add_string : t -> string -> string -> unit
+    val add_object : t -> string -> pyvalue -> unit
+    val add_fn : t -> string -> (Object.t -> pyvalue) -> unit
 end
 
 (*---------------------------------------------------------------------------

--- a/src/py.mli
+++ b/src/py.mli
@@ -364,6 +364,8 @@ module CamlModule : sig
     val add_string : t -> string -> string -> unit
     val add_object : t -> string -> pyvalue -> unit
     val add_fn : t -> string -> (Object.t -> pyvalue) -> unit
+
+    val capsule_wrapper : unit -> ('a -> Object.t) * (Object.t -> 'a)
 end
 
 (*---------------------------------------------------------------------------

--- a/test/ocaml_plugin.ml
+++ b/test/ocaml_plugin.ml
@@ -1,15 +1,12 @@
+let fn args =
+  let v = match Py.Object.to_list Py.Object.to_int args with
+  | [v] -> v
+  | _ -> assert false in
+  Py.List [ Int (v + 1337); String "hello from ocaml!" ]
+
 let () =
-  let m = Py.PyModule.get "testmod" in
-  Py.Object.incref m;
-  Printf.printf "Created module %s\n%!" (Py.Object.to_string m);
-
-  Py.PyModule.add_int m "foobar" 42;
-  Py.PyModule.add_string m "pi" "3.14159265358979";
-  let obj = Py.(!$ (List [String "e ="; Float 2.71828182846])) in
-  Py.Object.incref obj;
-  Py.PyModule.add_object m "e" obj;
-  Printf.printf "Attributes set!\n%!";
-
-  at_exit (fun () ->
-    Printf.printf "at_exit called\n%!";
-    ignore (Sys.opaque_identity m : Py.pyobject))
+  let m = Py.CamlModule.create "testmod" in
+  Py.CamlModule.add_int m "foobar" 42;
+  Py.CamlModule.add_string m "pi" "3.14159265358979";
+  Py.CamlModule.add_object m "e" (List [String "e ="; Float 2.71828182846]);
+  Py.CamlModule.add_fn m "fn" fn

--- a/test/ocaml_plugin.ml
+++ b/test/ocaml_plugin.ml
@@ -1,12 +1,35 @@
 let fn args =
-  let v = match Py.Object.to_list Py.Object.to_int args with
-  | [v] -> v
-  | _ -> assert false in
+  let v =
+      match Py.Object.to_list Py.Object.to_int args with
+      | [v] -> v
+      | _ -> failwith "not the expected format"
+  in
+  if v = 0
+  then failwith "ocaml issue";
   Py.List [ Int (v + 1337); String "hello from ocaml!" ]
+
+type t =
+  { mutable value : int }
 
 let () =
   let m = Py.CamlModule.create "testmod" in
   Py.CamlModule.add_int m "foobar" 42;
   Py.CamlModule.add_string m "pi" "3.14159265358979";
   Py.CamlModule.add_object m "e" (List [String "e ="; Float 2.71828182846]);
-  Py.CamlModule.add_fn m "fn" fn
+  Py.CamlModule.add_fn m "fn" fn;
+
+  (* Wrap a simple caml data-structure in a capsule. *)
+  let encapsulate, decapsulate = Py.CamlModule.capsule_wrapper () in
+  let build _args = Py.Ptr (encapsulate { value = 0 }) in
+  let increment args =
+      let t = decapsulate (Py.Object.get_item_i args 0) in
+      t.value <- t.value + 1;
+      Py.Nil
+  in
+  let get args =
+      let t = decapsulate (Py.Object.get_item_i args 0) in
+      Py.Int t.value
+  in
+  Py.CamlModule.add_fn m "build" build;
+  Py.CamlModule.add_fn m "increment" increment;
+  Py.CamlModule.add_fn m "get" get

--- a/test/run_ocaml_plugin.py
+++ b/test/run_ocaml_plugin.py
@@ -1,26 +1,32 @@
 # Run this from the github root directory via:
 #    dune build test/ocaml_plugin.so && python test/run_ocaml_plugin.py
+import atexit
 import ctypes
 import os
 
-os.environ['OCAML_PY_NO_INIT'] = 'true'
+ocaml_is_initialized = False
 
-print('Importing the ocaml library.')
-dll = ctypes.PyDLL('_build/default/test/ocaml_plugin.so', ctypes.RTLD_GLOBAL)
+def start_ocaml():
+  global ocaml_is_initialized
+  if ocaml_is_initialized: return
+  os.environ['OCAML_PY_NO_INIT'] = 'true'
+  dll = ctypes.PyDLL('_build/default/test/ocaml_plugin.so', ctypes.RTLD_GLOBAL)
+  argc = ctypes.c_int(2)
+  myargv = ctypes.c_char_p * 2
+  argv = myargv()
+  dll.caml_startup(argv)
+  ocaml_is_initialized = True
 
-print('Starting the ocaml runtime.')
-argc = ctypes.c_int(2)
-myargv = ctypes.c_char_p * 2
-argv = myargv()
-dll.caml_startup(argv)
+  def finalize():
+    dll.caml_shutdown()
+  atexit.register(finalize)
 
-print('Importing the ocaml module.');
+start_ocaml()
+
 import testmod
 
-print('Module imported has been imported.')
 print(testmod.foobar)
 print(testmod.pi)
 print(testmod.e)
-
-print('All good, shutting down the ocaml runtime.')
-dll.caml_shutdown()
+for i in range(10):
+  print(testmod.fn(i))

--- a/test/run_ocaml_plugin.py
+++ b/test/run_ocaml_plugin.py
@@ -28,5 +28,17 @@ import testmod
 print(testmod.foobar)
 print(testmod.pi)
 print(testmod.e)
-for i in range(10):
+for i in range(1, 10):
   print(testmod.fn(i))
+
+# OCaml errors should be nicely wrapped in Python.
+try:
+  testmod.fn(0)
+except Exception as e:
+  print('ocaml failed: ' + str(e))
+
+capsule = testmod.build()
+testmod.increment(capsule)
+testmod.increment(capsule)
+testmod.increment(capsule)
+print(testmod.get(capsule))


### PR DESCRIPTION
This extends the previous way to create new module from ocaml code by adding the possibility to add ocaml functions to the module. These functions can then be called from python.
It also extends on the python capsule side so that it's easy to store ocaml data types in 'opaque' python variables.

The example in the `data` directory gives some idea on how to use this: the ocaml code register a new module with some values and functions, and creates a capsule wrapper around some ocaml datatype.
The python code then loads the shared library that dune creates from the ocaml code, starts the ocaml runtime and performs various function calls.