### PR TITLE
Add some pretty-printer + make the pyobject type opaque.

### DIFF
--- a/src/py_base.ml
+++ b/src/py_base.ml
@@ -425,7 +425,19 @@ module Object = struct
     let concat a b =
         wrap (C._PySequence_Concat a b)
 
-    let to_c_pointer t str_option =
+    let pp formatter t =
+        let str =
+            if is_null t then "PyNull"
+            else try to_string t with _ -> "PyOpaque"
+        in
+        Format.open_box 0;
+        Format.fprintf formatter "%s" str;
+        Format.close_box ()
+
+    let to_c_ptr x = x
+    let of_c_ptr x = x
+
+    let capsule_c_pointer t str_option =
         let str_or_null =
             match str_option with
             | Some str -> CArray.of_string str |> CArray.start
@@ -740,7 +752,7 @@ module Numpy = struct
         let np_api =
             np $. String "core" $. String "multiarray" $. String "_ARRAY_API"
         in
-        let np_api = Object.to_c_pointer np_api None in
+        let np_api = Object.capsule_c_pointer np_api None in
         (* See [numpy/__multiarray_api.h] for the offset values. *)
         let ptr_offset ~offset = to_voidp (from_voidp (ptr void) np_api +@ offset) in
         let fn fn_typ ~offset =

--- a/src/py_base.mli
+++ b/src/py_base.mli
@@ -10,7 +10,7 @@
 
 (** {1 Py} *)
 
-type pyobject = unit Ctypes.ptr
+type pyobject
 val pyobject : pyobject Ctypes.typ
 
 (** The op type is used in calls to Object.compare *)
@@ -123,8 +123,14 @@ module Object : sig
     (** Call a Python Object *)
     val call : ?args:t -> ?kwargs:t -> t -> t
 
+    (** Top-level pretty printer. *)
+    val pp : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
+
+    val to_c_ptr : pyobject -> unit Ctypes.ptr
+    val of_c_ptr : unit Ctypes.ptr -> pyobject
+
     (** Extract the C pointer from a capsule *)
-    val to_c_pointer : t -> string option -> unit Ctypes.ptr
+    val capsule_c_pointer : t -> string option -> unit Ctypes.ptr
 end
 
 val wrap : pyobject -> Object.t


### PR DESCRIPTION
A small PR to add some pretty-printer for ocaml top-levels. Note that with recent versions of utop (2.3.0) the pretty-printer automatically gets installed so if you run `dune utop` you should be able to get the following immediately.
Additionnaly this makes the `pyobject` type abstract to avoid making it too easy to trigger some segfault by using a non pyobject pointer. The conversion to/from pointers are still exposed just in case (but maybe should not be part of the public api ?), incidently the capsule pointer extraction function has been renamed.

![image](https://user-images.githubusercontent.com/1041292/52170431-fa777100-2741-11e9-869a-933fd0f49970.png)
