### PR TITLE
Avoid some potential segfault when using call.

### DIFF
--- a/src/init.ml
+++ b/src/init.ml
@@ -90,6 +90,8 @@ let _PyObject_GetItem = foreign ~from "PyObject_GetItem" (pyobject @-> pyobject 
 let _PyObject_DelItem = foreign ~from "PyObject_DelItem" (pyobject @-> pyobject @-> returning int)
 let _PyObject_SetItem = foreign ~from "PyObject_SetItem" (pyobject @-> pyobject @-> pyobject @-> returning int)
 let _PyObject_GetAttr = foreign ~from "PyObject_GenericGetAttr" (pyobject @-> pyobject @-> returning pyobject)
+let _PyObject_GetAttrString =
+    foreign ~from "PyObject_GetAttrString" (pyobject @-> string @-> returning pyobject)
 let _PyObject_SetAttr = foreign ~from "PyObject_GenericSetAttr" (pyobject @-> pyobject @-> pyobject @-> returning int)
 let _PyObject_HasAttr = foreign ~from "PyObject_HasAttr" (pyobject @-> pyobject @-> returning bool)
 

--- a/src/py_base.mli
+++ b/src/py_base.mli
@@ -121,7 +121,10 @@ module Object : sig
     val concat : t -> t -> t
 
     (** Call a Python Object *)
-    val call : ?args:t -> ?kwargs:t -> t -> t
+    val call : ?args:t array -> ?kwargs:(t * t) list -> t -> t
+
+    (** Call a method on Python Object *)
+    val call_method : ?args:t array -> ?kwargs:(t * t) list -> t -> string -> t
 
     (** Top-level pretty printer. *)
     val pp : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]

--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -59,6 +59,21 @@ let py_test_iter t =
     let _ = Test.check t "Python check iter 3" (fun () -> Object.to_int o) 3 in
     Test.check_raise t "Python check iter end" (fun () -> PyIter.next i)
 
+let py_test_call t =
+    let python_list = PyList.create [] in
+    let result =
+        Object.call_method python_list "append" ~args:[| to_object (Int 42) |]
+    in
+    assert Object.(is_none result);
+    let result =
+        Object.call_method python_list "append" ~args:[| to_object (String "foo") |]
+    in
+    assert Object.(is_none result);
+    let len =
+        Object.(call (get_item_s (builtins ()) "len") ~args:[| python_list |])
+        |> Object.to_int
+    in
+    Test.check t "Python check call" (fun () -> len) 2
 
 let py_test_buffer t =
     let a = ['a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'] in
@@ -183,6 +198,7 @@ let simple = [
     py_test_dict;
     py_test_getitem_dict;
     py_test_iter;
+    py_test_call;
     py_test_buffer;
     py_test_wrap;
     py_test_thread_state;


### PR DESCRIPTION
`PyObject_Call` segfaults if its argument is not a tuple (e.g. on a python int). This is easy to trigger when we can pass any pyobject to this function. This PR tweaks the type for `args` and `kwargs` to enforce that they are always a tuple and a dictionary.
This also adds a `call_method` function for convenience and use `PyObject_GetAttrString` for `get_attr_s` to avoid some intermediary allocation.