### PR TITLE
Add a Py_type module.

### DIFF
--- a/src/init.ml
+++ b/src/init.ml
@@ -284,3 +284,40 @@ let _PyCapsule_New =
     (Foreign.funptr (pyobject @-> returning void)) @-> returning pyobject)
 
 let _PyCapsule_GetPointer = foreign ~from "PyCapsule_GetPointer" (pyobject @-> ptr char @-> returning (ptr void))
+
+(* See https://docs.python.org/3/c-api/typeobj.html for details on the C implementation. *)
+type _Py_type_object
+let _Py_type_object : _Py_type_object structure typ = structure "Py_type_object"
+let tp_refcnt = field _Py_type_object "ob_refcnt" PosixTypes.ssize_t
+let tp_type = field _Py_type_object "ob_type" (ptr _Py_type_object)
+let tp_size = field _Py_type_object "ob_size" PosixTypes.ssize_t
+let tp_name = field _Py_type_object "tp_name" string
+let tp_basicsize = field _Py_type_object "tp_basicsize" PosixTypes.ssize_t
+let tp_itemsize = field _Py_type_object "tp_itemsize" PosixTypes.ssize_t
+(* Method pointers, we don't use these so they are represented with [ptr void] *)
+let tp_dealloc = field _Py_type_object "tp_dealloc" (ptr void)
+let tp_print = field _Py_type_object "tp_print" (ptr void)
+let tp_getattr = field _Py_type_object "tp_getattr" (ptr void)
+let tp_setattr = field _Py_type_object "tp_setattr" (ptr void)
+let tp_as_async = field _Py_type_object "tp_as_async" (ptr void)
+let tp_repr = field _Py_type_object "tp_repr" (ptr void)
+let tp_as_number = field _Py_type_object "tp_as_number" (ptr void)
+let tp_as_sequence = field _Py_type_object "tp_as_sequence" (ptr void)
+let tp_as_mapping = field _Py_type_object "tp_as_mapping" (ptr void)
+let tp_hash = field _Py_type_object "tp_hash" (ptr void)
+let tp_call = field _Py_type_object "tp_call" (ptr void)
+let tp_str = field _Py_type_object "tp_str" (ptr void)
+let tp_getattro = field _Py_type_object "tp_getattro" (ptr void)
+let tp_setattro = field _Py_type_object "tp_setattro" (ptr void)
+let tp_as_buffer = field _Py_type_object "tp_as_buffer" (ptr void)
+let tp_flags = field _Py_type_object "tp_flags" ulong
+let tp_doc = field _Py_type_object "tp_doc" string
+let () = seal _Py_type_object
+
+type _Py_object
+let _Py_object : _Py_object structure typ = structure "Py_object"
+let ob_refcnt = field _Py_object "ob_refcnt" PosixTypes.ssize_t
+let ob_type = field _Py_object "ob_type" (ptr _Py_type_object)
+let () = seal _Py_object
+
+let _PyFloat_Type = foreign_value ~from "PyFloat_Type" _Py_type_object

--- a/src/py.ml
+++ b/src/py.ml
@@ -1,2 +1,3 @@
 include Py_base
 module PyWrap = Py_wrap
+module PyType = Py_type

--- a/src/py_type.ml
+++ b/src/py_type.ml
@@ -1,5 +1,15 @@
 module P = Py_base
 
+let type_name obj =
+  let ptr = P.Object.to_c_ptr obj |> Ctypes.from_voidp Init._Py_object in
+  if Ctypes.is_null ptr
+  then None
+  else
+    let ob_type = Ctypes.getf (Ctypes.(!@) ptr) Init.ob_type in
+    if Ctypes.is_null ob_type
+    then None
+    else Some (Ctypes.getf (Ctypes.(!@) ob_type) Init.tp_name)
+
 let tp_flags obj =
   let ptr = P.Object.to_c_ptr obj |> Ctypes.from_voidp Init._Py_object in
   if Ctypes.is_null ptr

--- a/src/py_type.ml
+++ b/src/py_type.ml
@@ -1,0 +1,80 @@
+module P = Py_base
+
+let tp_flags obj =
+  let ptr = P.Object.to_c_ptr obj |> Ctypes.from_voidp Init._Py_object in
+  if Ctypes.is_null ptr
+  then None
+  else
+    let ob_type = Ctypes.getf (Ctypes.(!@) ptr) Init.ob_type in
+    if Ctypes.is_null ob_type
+    then None
+    else
+      let tp_flags = Ctypes.getf (Ctypes.(!@) ob_type) Init.tp_flags in
+      Some (Unsigned.ULong.to_int tp_flags)
+
+let has_flag' tp_flags ~flag_id =
+  match tp_flags with
+  | None -> false
+  | Some tp_flags -> (tp_flags land (1 lsl flag_id)) <> 0
+
+let has_flag obj ~flag_id = tp_flags obj |> has_flag' ~flag_id
+
+(* The related cpython constants can be found in:
+   https://github.com/python/cpython/blob/master/Include/object.h
+*)
+
+let long_subclass = has_flag ~flag_id:24
+let list_subclass = has_flag ~flag_id:25
+let tuple_subclass = has_flag ~flag_id:26
+let bytes_subclass = has_flag ~flag_id:27
+let unicode_subclass = has_flag ~flag_id:28
+let dict_subclass = has_flag ~flag_id:29
+let base_exc_subclass = has_flag ~flag_id:30
+let type_subclass = has_flag ~flag_id:31
+
+(* Floats are not handled in the same way as other basic
+   types so we compare the object type with the float  object
+   type. This will not work for float subclasses.
+*)
+let is_float obj =
+  let ptr = P.Object.to_c_ptr obj |> Ctypes.from_voidp Init._Py_object in
+  if Ctypes.is_null ptr
+  then false
+  else
+    let ob_type = Ctypes.getf (Ctypes.(!@) ptr) Init.ob_type in
+    Ctypes.ptr_compare ob_type Init._PyFloat_Type = 0
+
+type t =
+  | Null
+  | None
+  | Long
+  | List
+  | Tuple
+  | Bytes
+  | Unicode
+  | Dict
+  | Base_exc
+  | Type
+  | Float
+
+let get obj =
+  if P.Object.is_null obj
+  then [ Null ]
+  else if P.Object.is_none obj
+  then [ None ]
+  else
+    let tp_flags = tp_flags obj in
+    let maybe_add v ~flag_id acc =
+      if has_flag' tp_flags ~flag_id
+      then v :: acc
+      else acc
+    in
+    (if is_float obj then [ Float ] else [])
+    |> maybe_add Long ~flag_id:24
+    |> maybe_add List ~flag_id:25
+    |> maybe_add Tuple ~flag_id:26
+    |> maybe_add Bytes ~flag_id:27
+    |> maybe_add Unicode ~flag_id:28
+    |> maybe_add Dict ~flag_id:29
+    |> maybe_add Base_exc ~flag_id:30
+    |> maybe_add Type ~flag_id:31

--- a/src/py_type.mli
+++ b/src/py_type.mli
@@ -23,3 +23,4 @@ val base_exc_subclass : Py_base.pyobject -> bool
 val type_subclass : Py_base.pyobject -> bool
 
 val is_float : Py_base.pyobject -> bool
+val type_name : Py_base.pyobject -> string option

--- a/src/py_type.mli
+++ b/src/py_type.mli
@@ -1,0 +1,25 @@
+type t =
+  | Null
+  | None
+  | Long
+  | List
+  | Tuple
+  | Bytes
+  | Unicode
+  | Dict
+  | Base_exc
+  | Type
+  | Float
+
+val get : Py_base.pyobject -> t list
+
+val long_subclass : Py_base.pyobject -> bool
+val list_subclass : Py_base.pyobject -> bool
+val tuple_subclass : Py_base.pyobject -> bool
+val bytes_subclass : Py_base.pyobject -> bool
+val unicode_subclass : Py_base.pyobject -> bool
+val dict_subclass : Py_base.pyobject -> bool
+val base_exc_subclass : Py_base.pyobject -> bool
+val type_subclass : Py_base.pyobject -> bool
+
+val is_float : Py_base.pyobject -> bool

--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -47,8 +47,14 @@ let py_test_getitem_dict t =
 let py_test_type t =
     List.iter
         (fun (name, py, expected_type) ->
-            let type_ = PyType.get (!$ py) in
-            Test.check t ("Type " ^ name) (fun () -> type_) expected_type)
+            let pyobject = !$ py in
+            let type_name =
+              match PyType.type_name pyobject with
+              | None -> assert false
+              | Some type_name -> type_name
+            in
+            Test.check t ("Type " ^ name) (fun () -> type_name) name;
+            Test.check t ("Type " ^ name) (fun () -> PyType.get pyobject) expected_type)
         [
             "str", String "foobar", [Unicode];
             "int", Int 42, [Long];
@@ -56,7 +62,7 @@ let py_test_type t =
             "tuple", Tuple [|String "alpha"; Int 42|], [Tuple];
             "list", List [String "alpha"; Int 42], [List];
             "float", Float 3.14159265359, [Float];
-            "none", Nil, [None];
+            "NoneType", Nil, [None];
         ]
 
 

--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -44,6 +44,22 @@ let py_test_getitem_dict t =
     Test.check t "Getitem a" (fun () -> Object.get_item_s d "a" |> Object.to_int) 1;
     Test.check t "Getitem b" (fun () -> Object.get_item d (PyUnicode.create "b") |> Object.to_int) 3
 
+let py_test_type t =
+    List.iter
+        (fun (name, py, expected_type) ->
+            let type_ = PyType.get (!$ py) in
+            Test.check t ("Type " ^ name) (fun () -> type_) expected_type)
+        [
+            "str", String "foobar", [Unicode];
+            "int", Int 42, [Long];
+            "dict", Dict [String "key", Int 42], [Dict];
+            "tuple", Tuple [|String "alpha"; Int 42|], [Tuple];
+            "list", List [String "alpha"; Int 42], [List];
+            "float", Float 3.14159265359, [Float];
+            "none", Nil, [None];
+        ]
+
+
 let py_test_iter t =
     let l = !$(List [
         Int 1;
@@ -197,6 +213,7 @@ let simple = [
     py_test_tuple;
     py_test_dict;
     py_test_getitem_dict;
+    py_test_type;
     py_test_iter;
     py_test_call;
     py_test_buffer;


### PR DESCRIPTION
This PR adds a new `PyType` module to extract type information from a `Py.pyobject`. This works by accessing the `tp_flags` field on the type object. An object can have multiple types because of inheritance so a list of type is returned. Maybe would it be worth having an helper function that returns a single type if possible and either throws on multiple types or has a specific variant for this.

Hopefully this `PyType` module could be leveraged to write the inverse of `Py.to_object`, i.e. a function taking a python object and returning a nice ocaml representation if possible.