### PR TITLE
Convert from pyobjects back to Py.t.

### DIFF
--- a/src/py.ml
+++ b/src/py.ml
@@ -1,3 +1,5 @@
 include Py_base
 module PyWrap = Py_wrap
 module PyType = Py_type
+
+let of_object : Object.t -> t = PyType.of_object

--- a/src/py_type.ml
+++ b/src/py_type.ml
@@ -88,3 +88,15 @@ let get obj =
     |> maybe_add Dict ~flag_id:29
     |> maybe_add Base_exc ~flag_id:30
     |> maybe_add Type ~flag_id:31
+
+let rec of_object obj : P.t =
+  match get obj with
+  | [ Null ] | [ None ] -> Nil
+  | [ Float ] -> Float (P.Object.to_float obj)
+  | [ Long ] -> Int (P.Object.to_int obj)
+  | [ List ] -> List (P.Object.to_list of_object obj)
+  | [ Tuple ] -> Tuple (P.Object.to_array of_object obj)
+  | [ Bytes ] -> Bytes (P.Object.to_bytes obj)
+  | [ Unicode ] -> String (P.Object.to_string obj)
+  | [ Dict ] -> Dict (P.PyDict.items of_object of_object obj)
+  | _ -> Ptr obj

--- a/src/py_type.mli
+++ b/src/py_type.mli
@@ -24,3 +24,5 @@ val type_subclass : Py_base.pyobject -> bool
 
 val is_float : Py_base.pyobject -> bool
 val type_name : Py_base.pyobject -> string option
+
+val of_object : Py_base.pyobject -> Py_base.t

--- a/test/py_test.ml
+++ b/test/py_test.ml
@@ -65,6 +65,18 @@ let py_test_type t =
             "NoneType", Nil, [None];
         ]
 
+let py_test_of_object t =
+    List.iteri
+        (fun i py ->
+            let py' = !$ py |> of_object in
+            Test.check t ("of_object " ^ string_of_int i) (fun () -> py) py')
+        [
+            String "foobar";
+            Int 42;
+            Dict [String "key", Int 42; Int 1337, Float 3.1415];
+            List [Tuple [|Int 2; Int 7; Int 1; Float 828.|]; String "test"; Nil];
+        ]
+
 
 let py_test_iter t =
     let l = !$(List [
@@ -220,6 +232,7 @@ let simple = [
     py_test_dict;
     py_test_getitem_dict;
     py_test_type;
+    py_test_of_object;
     py_test_iter;
     py_test_call;
     py_test_buffer;


### PR DESCRIPTION
Add an `of_object` function that takes an arbitrary python object and converts it back to a `Py.t` value (defaulting to the `Ptr` variant for unknown values).

A missing bit is booleans as it's not immediately clear to me what is the best way to lookup the type of these.